### PR TITLE
Chore / Modificación para headers en vista móvil

### DIFF
--- a/src/components/headers.css
+++ b/src/components/headers.css
@@ -13,7 +13,7 @@
     }
 
     &.add-on-container {
-      @apply lg:w-2/5 min-w-min px-4 py-4 flex justify-center lg:justify-end space-x-6;
+      @apply lg:w-2/5 min-w-min px-0 lg:px-4 py-4 flex justify-end lg:justify-end space-x-6;
     }
 
     &.title {


### PR DESCRIPTION
# Contexto
Se requieren cambios visuales para mejorar el componente de headers en vista móvil.

# Cambios
- Se elimina el padding lateral en versión móvil para que todo este alineado correctamente con el titulo y la descripción
- Se modificó el justify-center por justify-end para que los iconos se muevan a la derecha en vista móvil

# Screenshots

## Versión previa
![141526614-2ef18c59-e53f-4de4-8e30-611e372ea16d-2](https://user-images.githubusercontent.com/92053663/142073253-63091f25-6f07-4d9b-b591-f0e909bc87b2.png)


## Versión actualizada
![Captura de Pantalla 2021-11-16 a la(s) 3 52 40 p m](https://user-images.githubusercontent.com/92053663/142073263-9311a40a-4860-4ade-886e-92d721a845fc.png)
